### PR TITLE
 Fix the ordering of the essential basic guides

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,6 +13,7 @@
 :page-releasedate: 2017-12-27
 :page-guide-category: basic
 :page-essential: true
+:page-essential-order: 2
 :page-tags: ['Gradle', 'Getting Started']
 :page-permalink: /guides/{projectid}
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/master


### PR DESCRIPTION
- Related to OpenLiberty/openliberty.io#287