### PR TITLE
Update dependency javax.servlet to 4.0

### DIFF
--- a/finish/build.gradle
+++ b/finish/build.gradle
@@ -33,7 +33,7 @@ repositories {
 
 // tag::dependencies[]
 dependencies {
-    providedCompile group:'javax.servlet', name:'javax.servlet-api', version:'4.0.0'
+    providedCompile group:'javax.servlet', name:'javax.servlet-api', version:'4.0.1'
     testCompile group:'commons-httpclient', name:'commons-httpclient', version:'3.1'
     testCompile group:'junit', name:'junit', version:'4.12'
     libertyRuntime group:'io.openliberty', name:'openliberty-runtime', version:'[17.0.0.4,)'

--- a/finish/build.gradle
+++ b/finish/build.gradle
@@ -33,7 +33,7 @@ repositories {
 
 // tag::dependencies[]
 dependencies {
-    providedCompile group:'javax.servlet', name:'javax.servlet-api', version:'3.1.0'
+    providedCompile group:'javax.servlet', name:'javax.servlet-api', version:'4.0'
     testCompile group:'commons-httpclient', name:'commons-httpclient', version:'3.1'
     testCompile group:'junit', name:'junit', version:'4.12'
     libertyRuntime group:'io.openliberty', name:'openliberty-runtime', version:'[17.0.0.4,)'

--- a/finish/build.gradle
+++ b/finish/build.gradle
@@ -33,7 +33,7 @@ repositories {
 
 // tag::dependencies[]
 dependencies {
-    providedCompile group:'javax.servlet', name:'javax.servlet-api', version:'4.0'
+    providedCompile group:'javax.servlet', name:'javax.servlet-api', version:'4.0.0'
     testCompile group:'commons-httpclient', name:'commons-httpclient', version:'3.1'
     testCompile group:'junit', name:'junit', version:'4.12'
     libertyRuntime group:'io.openliberty', name:'openliberty-runtime', version:'[17.0.0.4,)'


### PR DESCRIPTION
the version should match to the servlet-4.0 feature used in the server.xml
```
- wlp\lib\features\com.ibm.websphere.appserver.servlet-4.0.mf -> com.ibm.websphere.appserver.javax.servlet-4.0 
- wlp\lib\features\com.ibm.websphere.appserver.javax.servlet-4.0.mf -> mavenCoordinates="javax.servlet:javax.servlet-api:4.0.1"
```