### PR TITLE
Update to MP6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: gradle
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -1,0 +1,18 @@
+name: Add PRs to Dependabot PRs dashboard
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add PR to dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/OpenLiberty/projects/26
+          github-token: ${{ secrets.ADMIN_BACKLOG }}
+          labeled: dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 .project
 README.html
 .DS_Store
+bin/

--- a/finish/build.gradle
+++ b/finish/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     }
     dependencies {
         // tag::liberty-dependency[]
-        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.5.2'
+        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.7'
         // end::liberty-dependency[]
     }
 }
@@ -40,16 +40,16 @@ dependencies {
     // provided dependencies
     // tag::providedcompile[]
     providedCompile 'jakarta.platform:jakarta.jakartaee-api:10.0.0'
-    providedCompile 'org.eclipse.microprofile:microprofile:6.0'
+    providedCompile 'org.eclipse.microprofile:microprofile:6.1'
     // end::providedcompile[]
 
     // test dependencies
     // tag::testimplementation[]
     // tag::junit[]
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
     // end::junit[]
     // tag::commons[]
-    testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
+    testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.3.1'
     // end::commons[]
     // end::testimplementation[]
 }
@@ -57,8 +57,8 @@ dependencies {
 
 // tag::ext[]
 ext  {
-    liberty.server.var.'default.http.port' = '9080'
-    liberty.server.var.'default.https.port' = '9443'
+    liberty.server.var.'http.port' = '9080'
+    liberty.server.var.'https.port' = '9443'
     liberty.server.var.'app.context.root' = project.name
 }
 // end::ext[]
@@ -67,7 +67,7 @@ ext  {
 task openBrowser {
     description = 'Open browser to the running application'
     doLast {
-        String port = liberty.server.var.'default.http.port'
+        String port = liberty.server.var.'http.port'
         String context = liberty.server.var.'app.context.root'
         String URL = "http://localhost:" + port + "/" + context + "/" + "servlet"
         java.awt.Desktop.desktop.browse URL.toURI()
@@ -87,7 +87,7 @@ test {
     }
     // tag::systemproperty[]
     // tag::httpport[]
-    systemProperty 'http.port', liberty.server.var.'default.http.port'
+    systemProperty 'http.port', liberty.server.var.'http.port'
     // end::httpport[]
     // tag::contextroot[]
     systemProperty 'context.root',  liberty.server.var.'app.context.root'

--- a/finish/src/main/liberty/config/server.xml
+++ b/finish/src/main/liberty/config/server.xml
@@ -3,7 +3,7 @@
         <feature>servlet-6.0</feature>
     </featureManager>
 
-    <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint"  host="*" />
+    <httpEndpoint httpPort="${http.port}" httpsPort="${https.port}" id="defaultHttpEndpoint"  host="*" />
 
     <webApplication id="GradleSample" location="GradleSample.war" contextRoot="${app.context.root}" />
 </server>

--- a/finish/src/test/java/io/openliberty/guides/hello/it/EndpointIT.java
+++ b/finish/src/test/java/io/openliberty/guides/hello/it/EndpointIT.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,11 +18,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 
-import org.apache.http.HttpStatus;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.HttpStatus;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 // end::import[]
@@ -46,7 +46,7 @@ public class EndpointIT {
     // end::test[]
     public void testServlet() throws Exception {
 
-        CloseableHttpClient client = HttpClientBuilder.create().build();
+        CloseableHttpClient client = HttpClients.createDefault();
         HttpGet httpGet = new HttpGet(webURL);
         CloseableHttpResponse response = null;
 
@@ -54,7 +54,7 @@ public class EndpointIT {
         try {
             response = client.execute(httpGet);
 
-            int statusCode = response.getStatusLine().getStatusCode();
+            int statusCode = response.getCode();
             assertEquals(HttpStatus.SC_OK, statusCode, "HTTP GET failed");
 
             BufferedReader reader = new BufferedReader(new InputStreamReader(
@@ -69,7 +69,6 @@ public class EndpointIT {
                 "Unexpected response body: " + buffer.toString());
         } finally {
             response.close();
-            httpGet.releaseConnection();
         }
         // end::try[]
     }

--- a/start/src/main/liberty/config/server.xml
+++ b/start/src/main/liberty/config/server.xml
@@ -3,7 +3,7 @@
         <feature>servlet-6.0</feature>
     </featureManager>
 
-    <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint"  host="*" />
+    <httpEndpoint httpPort="${http.port}" httpsPort="${https.port}" id="defaultHttpEndpoint"  host="*" />
 
     <webApplication id="GradleSample" location="GradleSample.war" contextRoot="${app.context.root}" />
 </server>


### PR DESCRIPTION
address issue: https://github.com/OpenLiberty/guides-common/issues/1021

### Review changes
- [ ] pom.xml
  - microfile-profile is 6.1, and dependencies
  - LMP 3.10
  - `default.` should be removed
  - ports `9090`,`9453`,`9091`,`9454` if guide uses local kube
- [ ] server.xml
  - feature version
- [ ] index.html
  - feature version
- [ ] update lgdev with `version-update-mp61` branch
- [ ] do end-to-end test and review content carefully
  - clone the `version-update-mp61` branch
  - if index.html has changes, make sure the links work

